### PR TITLE
Add methods for metrics get meetings API

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -90,6 +90,30 @@ export type Registrant = {
   create_time?: string;
   join_url?: string;
 };
+export type MetricMeeting = {
+  uuid: string;
+  id: string; // int64 long, string in JS
+  topic: string;
+  host: string;
+  email: string;
+  user_type: string;
+  start_time: string;
+  end_time: string;
+  duration: string;
+  participants: number;
+  has_pstn: boolean;
+  has_voip: boolean;
+  has_3rd_party_audio: boolean;
+  has_video: boolean;
+  has_screen_share: boolean;
+  has_recording: boolean;
+  has_sip: boolean;
+  has_archiving: boolean;
+  in_room_participants: number;
+  dept: string;
+  custom_keys: { key: string; value: string }[];
+  tracking_fields: { field: string; value: string }[]
+};
 export type ListRegistrantsResponse = PaginatedResponse & {
   registrants: Registrant[];
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import users from './users';
 import meetings from './meetings';
 import webinars from './webinars';
+import metrics from './metrics';
 import reports from './reports';
 import { ZoomOptions } from './common';
 import request from './util/request';
@@ -12,6 +13,7 @@ export default function(zoomApiOpts: ZoomOptions) {
     users: users(zoomRequest),
     meetings: meetings(zoomRequest),
     webinars: webinars(zoomRequest),
+    metrics: metrics(zoomRequest),
     reports: reports(zoomRequest),
   };
 }
@@ -20,4 +22,5 @@ export * from './webhooks';
 export * from './common';
 export * from './users';
 export * from './meetings';
+export * from './metrics';
 export * from './reports';

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,30 @@
+import { MetricMeeting, PaginatedResponse } from './common';
+import request from './util/request';
+
+export type GetMetricsMeetingsParams = {
+  type?: 'past' | 'pastOne' | 'live';
+  from: string;
+  to: string;
+  page_size?: number;
+  page_next_token?: string;
+  include_fields?: 'tracking_fields';
+};
+
+export type GetMetricsMeetingsResponse = PaginatedResponse & {
+  from: string;
+  to: string;
+  next_page_token: string;
+  meetings: MetricMeeting[]
+};
+
+export default function metrics(zoomRequest: ReturnType<typeof request>) {
+  return {
+    GetMeetings(params?: GetMetricsMeetingsParams) {
+      return zoomRequest<GetMetricsMeetingsResponse>({
+        method: 'GET',
+        path: '/metrics/meetings',
+        params,
+      });
+    }
+  };
+}

--- a/src/reports.ts
+++ b/src/reports.ts
@@ -2,6 +2,7 @@ import { PaginatedResponse } from './common';
 import request from './util/request';
 
 export type GetMeetingParticipantReportsParams = {
+  page_size?: number;
   next_page_token?: string;
   include_fields?: 'registrant_id';
 };

--- a/src/reports.ts
+++ b/src/reports.ts
@@ -2,13 +2,12 @@ import { PaginatedResponse } from './common';
 import request from './util/request';
 
 export type GetMeetingParticipantReportsParams = {
-  page_size?: number
-  next_page_token?: string
-  include_fields?: 'registrant_id'
+  next_page_token?: string;
+  include_fields?: 'registrant_id';
 };
 
 export type GetMeetingParticipantReportsResponse = PaginatedResponse & {
-  next_page_token: string
+  next_page_token: string;
   participants: {
     id: string;
     user_id: string;


### PR DESCRIPTION
Upstream documentation at https://marketplace.zoom.us/docs/api-reference/zoom-api/dashboards/dashboardmeetings

I had the choice between calling it "Dashboards" and "Metrics". I went with the url for the API instead of the label