### PR TITLE
Support for server-to-server OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 NodeJS library for working with the Zoom API.
 
-`zoomapi` provides server-side access to the [Zoom APIs](https://marketplace.zoom.us/docs/api-reference/introduction) via JWT access tokens. It's written completely in Typescript, and only has one dependency. Works on NodeJS version 8 and higher.
+`zoomapi` provides server-side access to the [Zoom APIs](https://marketplace.zoom.us/docs/api-reference/introduction) via [JWT access tokens (deprecation scheduled for June 2023)](https://marketplace.zoom.us/docs/guides/build/jwt-app/) or [server-to-server OAuth](https://marketplace.zoom.us/docs/guides/build/server-to-server-oauth-app/). It's written completely in Typescript, and only has one dependency. Works on NodeJS version 8 and higher.
 
 ```js
 npm i zoomapi
@@ -13,10 +13,18 @@ npm i zoomapi
 ```js
 import zoomApi from 'zoomapi';
 
+// JWT app
 const client = zoomApi({
   apiKey: process.NODE_ENV.ZoomApiKey,
   apiSecret: process.NODE_ENV.ZoomApiSecret
 });
+// or Server-to-Server OAuth app
+const client = zoomApi({
+  accountId: process.NODE_ENV.ZoomAccountId,
+  oauthClientId: process.NODE_ENV.ZoomOAuthClientId,
+  oauthClientSecret: process.NODE_ENV.ZoomOAuthClientSecret,
+});
+
 const users = await client.users.ListUsers();
 ```
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,8 +1,14 @@
-export type ZoomOptions = {
+export type ZoomJWTOptions = {
   apiKey: string;
   apiSecret: string;
   tokenExpiresIn?: string | number;
 };
+export type ZoomOAuthOptions = {
+  accountId: string;
+  oauthClientId: string;
+  oauthClientSecret: string;
+};
+export type ZoomOptions = ZoomJWTOptions | ZoomOAuthOptions;
 export type ListResponse = {
   total_records: number;
 };

--- a/src/util/ZoomError.ts
+++ b/src/util/ZoomError.ts
@@ -1,0 +1,12 @@
+export default class ZoomError extends Error {
+  httpStatusCode: number;
+  errorCode: number | null;
+  response: string;
+  constructor(httpStatusCode: number, errorCode: number | null, message: string, response: string) {
+    super();
+    this.httpStatusCode = httpStatusCode;
+    this.errorCode = errorCode;
+    this.message = message;
+    this.response = response;
+  }
+}

--- a/src/util/getAuthToken.ts
+++ b/src/util/getAuthToken.ts
@@ -1,7 +1,24 @@
+import https from 'https';
 import jwt from 'jsonwebtoken';
-import { ZoomOptions } from '../';
+import type { 
+  ZoomOptions,
+  ZoomJWTOptions,
+  ZoomOAuthOptions,
+} from '../';
+import ZoomError from './ZoomError';
 
-export default function getAuthToken(zoomApiOpts: ZoomOptions) {
+type OauthTokenResponse = {
+  access_token: string;
+  token_type: 'bearer';
+  expire_in: number;
+  scope: string[];
+};
+
+const isJWTOptions = function(zoomApiOpts: ZoomOptions): zoomApiOpts is ZoomJWTOptions {
+  return 'apiKey' in zoomApiOpts;
+};
+
+const getJWTAuthToken = function(zoomApiOpts: ZoomJWTOptions) {
   const payload = {
     iss: zoomApiOpts.apiKey
   };
@@ -15,4 +32,59 @@ export default function getAuthToken(zoomApiOpts: ZoomOptions) {
       return resolve(res);
     });
   });
+};
+
+const getServerToServerOAuthToken = async function(zoomApiOpts: ZoomOAuthOptions) {
+  // new Buffer(string) if we need to be compatible with Node 8,
+  // otherwise from Node 10 we should use Buffer.from(string)
+  const basicAuthToken = new Buffer(`${zoomApiOpts.oauthClientId}:${zoomApiOpts.oauthClientSecret}`).toString('base64');
+  const requestOpts = {
+    method: 'POST',
+    hostname: 'zoom.us',
+    path: `/oauth/token?grant_type=account_credentials&account_id=${encodeURIComponent(zoomApiOpts.accountId)}`,
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Basic ${basicAuthToken}`
+    }
+  };
+  return await new Promise<string>((resolve, reject) => {
+    const httpsRequest = https.request(requestOpts, (res) => {
+      const data: any[] = [];
+      res.on('data', (chunk) => {
+        data.push(chunk);
+      });
+      res.on('end', () => {
+        const dataStr = Buffer.concat(data).toString();
+        let body = {} as any;
+        try {
+          if (dataStr) {
+            body = JSON.parse(dataStr);
+          }
+        } catch (err) {
+          // JSON parse error
+          reject(new ZoomError(res.statusCode, null, 'Malformed JSON response from Zoom API', dataStr));
+          return;
+        }
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          reject(new ZoomError(res.statusCode, body.code, body.message, dataStr));
+        } else {
+          resolve((body as OauthTokenResponse).access_token);
+        }
+      });
+    });
+
+    httpsRequest.on('error', (err) => {
+      reject(err);
+    });
+
+    httpsRequest.end();
+  });
+};
+
+export default function getAuthToken(zoomApiOpts: ZoomOptions) {
+  if (isJWTOptions(zoomApiOpts)) {
+    return getJWTAuthToken(zoomApiOpts);
+  }
+
+  return getServerToServerOAuthToken(zoomApiOpts);
 }

--- a/src/util/getAuthToken.ts
+++ b/src/util/getAuthToken.ts
@@ -62,7 +62,7 @@ const getServerToServerOAuthToken = async function(zoomApiOpts: ZoomOAuthOptions
           }
         } catch (err) {
           // JSON parse error
-          reject(new ZoomError(res.statusCode, null, 'Malformed JSON response from Zoom API', dataStr));
+          reject(new ZoomError(res.statusCode, null, 'Malformed JSON response from Zoom OAuth token API', dataStr));
           return;
         }
         if (res.statusCode < 200 || res.statusCode >= 300) {

--- a/src/util/request.ts
+++ b/src/util/request.ts
@@ -1,6 +1,7 @@
 import https from 'https';
 import getAuthToken from './getAuthToken';
 import { ZoomOptions } from '../';
+import ZoomError from './ZoomError';
 
 const BASE_URL = 'api.zoom.us';
 const API_VERSION = '/v2';
@@ -14,19 +15,6 @@ type ZoomRequestOpts = {
   params?: QueryParams;
   body?: object;
 };
-
-class ZoomError extends Error {
-  httpStatusCode: number;
-  errorCode: number | null;
-  response: string;
-  constructor(httpStatusCode: number, errorCode: number | null, message: string, response: string) {
-    super();
-    this.httpStatusCode = httpStatusCode;
-    this.errorCode = errorCode;
-    this.message = message;
-    this.response = response;
-  }
-}
 
 const buildURL = function(url: string, params?: QueryParams) {
   if (!params) {


### PR DESCRIPTION
JWT apps will be deprecated in June 2023 (see https://marketplace.zoom.us/docs/guides/build/jwt-app/).
Zoom recommends switching to OAuth or Server-to-Server OAuth apps.

This PR adds support for Server-to-Server OAuth, while keeping support for JWT apps.
Changes include an alternative set of options for the lib and an OAuth specific function to get an auth token.