### PR TITLE
fix: update ListMeetingParams to support next_page_token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 package-lock.json
 lib/
 test.ts
+.idea

--- a/src/meetings.ts
+++ b/src/meetings.ts
@@ -84,11 +84,14 @@ export type Meeting = {
   recurrence?: Recurrence;
 };
 export type ListMeetingsParams = {
-  type?: 'scheduled' | 'live' | 'upcoming';
+  type?: 'scheduled' | 'live' | 'upcoming' | 'upcoming_meetings' | 'previous_meetings';
   page_size?: number;
   page_number?: number;
+  next_page_token?: string;
 };
 export type ListMeetingsResponse = PaginatedResponse & {
+  // Note, the properties on the list meeting response is truncated.
+  // Please see https://developers.zoom.us/docs/api/meetings/#tag/meetings/get/users/{userId}/meetings
   meetings: Meeting[];
 };
 export type GetMeetingParams = {


### PR DESCRIPTION
Updates ListMeetingsParams to include next_page_token and extends the types as per documentation